### PR TITLE
GitHub Actionsが失敗しているのを修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
 
     - name: Get Docker image
       run: docker-compose pull
+      continue-on-error: true
 
     - name: Build Docker image
       run: docker-compose build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.2'
 services:
   iqgt-pdf-compile:
-    image: iqgt:latest
+    image: ghcr.io/morimorijap/iqgt:latest
     build:
       context: .
       dockerfile: ./docker/Dockerfile
       cache_from:
-        - iqgt:latest
+        - ghcr.io/morimorijap/iqgt:latest
     volumes:
       - .:/workdir


### PR DESCRIPTION
- 現在、次のようなエラーが生じてしまっている
    ```
    Run docker-compose push
    Pushing iqgt-pdf-compile (iqgt:latest)...
    The push refers to repository [docker.io/library/iqgt]
    denied: requested access to the resource is denied
    Error: Process completed with exit code 1.
    ```
    - https://github.com/morimorijap/Introduction_Quantum_GameTheory/runs/4578924271?check_suite_focus=true
- このエラーはDockerイメージを`docker.io`へとPushしようとしているが、今回はGitHubのDockerレジストリーである`ghcr.io`を利用したい
    - またGitHubのDockerレジストリーはGitHubのユーザー名をDockerイメージの名称に入れる必要がある（？）
- そのため`docker-compose.yml`のDockerイメージ名に`ghcr.io/morimorijap`を追加した
- また、そうすると初回の`docker-compose pull`が`ghcr.io`にDockerイメージがない！となって失敗してしまうが、ない場合にはビルドを行えばいいので無視する設定を追加した
    - 初回以降はイメージがPushされるため、ここが成功するはず……
- 自分の`main`ブランチでうまく動くことを確認した
    - https://github.com/y-yu/Introduction_Quantum_GameTheory/actions/runs/1603129044